### PR TITLE
Add support for buffered digital output

### DIFF
--- a/Bonsai.DAQmx/DigitalOutput.cs
+++ b/Bonsai.DAQmx/DigitalOutput.cs
@@ -4,13 +4,38 @@ using NationalInstruments.DAQmx;
 using System.Reactive.Disposables;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using OpenCV.Net;
+using System.Runtime.InteropServices;
 
 namespace Bonsai.DAQmx
 {
     [Description("Writes a sequence of logical values to one or more DAQmx digital output channels.")]
-    public class DigitalOutput : Sink<bool>
+    public class DigitalOutput : Sink<Mat>
     {
         readonly Collection<DigitalOutputChannelConfiguration> channels = new Collection<DigitalOutputChannelConfiguration>();
+
+        public DigitalOutput()
+        {
+            BufferSize = 1000;
+            SignalSource = string.Empty;
+            ActiveEdge = SampleClockActiveEdge.Rising;
+            SampleMode = SampleQuantityMode.ContinuousSamples;
+        }
+
+        [Description("The optional source terminal of the clock. If not specified, the internal clock of the device will be used.")]
+        public string SignalSource { get; set; }
+
+        [Description("The sampling rate, in samples per second.")]
+        public double SampleRate { get; set; }
+
+        [Description("The edges of sample clock pulses on which to generate samples.")]
+        public SampleClockActiveEdge ActiveEdge { get; set; }
+
+        [Description("Specifies whether signal generation is finite, or continuous.")]
+        public SampleQuantityMode SampleMode { get; set; }
+
+        [Description("The number of samples to generate, for finite samples, or the size of the buffer for continuous sampling.")]
+        public int BufferSize { get; set; }
 
         [Description("The collection of digital output channels used to generate digital signals.")]
         public Collection<DigitalOutputChannelConfiguration> Channels
@@ -18,7 +43,7 @@ namespace Bonsai.DAQmx
             get { return channels; }
         }
 
-        public override IObservable<bool> Process(IObservable<bool> source)
+        public IObservable<bool> Process(IObservable<bool> source)
         {
             return Observable.Defer(() =>
             {
@@ -29,7 +54,7 @@ namespace Bonsai.DAQmx
                 }
 
                 task.Control(TaskAction.Verify);
-                var digitalInReader = new DigitalMultiChannelWriter(task.Stream);
+                var digitalOutWriter = new DigitalMultiChannelWriter(task.Stream);
                 return Observable.Using(
                     () => Disposable.Create(() =>
                     {
@@ -39,7 +64,46 @@ namespace Bonsai.DAQmx
                     }),
                     resource => source.Do(input =>
                     {
-                        digitalInReader.WriteSingleSampleSingleLine(true, new[] { input });
+                        digitalOutWriter.WriteSingleSampleSingleLine(autoStart: true, new[] { input });
+                    }));
+            });
+        }
+
+        public override IObservable<Mat> Process(IObservable<Mat> source)
+        {
+            return Observable.Defer(() =>
+            {
+                var task = new Task();
+                foreach (var channel in channels)
+                {
+                    task.DOChannels.CreateChannel(channel.Lines, channel.ChannelName, channel.Grouping);
+                }
+
+                task.Control(TaskAction.Verify);
+                task.Timing.ConfigureSampleClock(SignalSource, SampleRate, ActiveEdge, SampleMode, BufferSize);
+                var digitalOutWriter = new DigitalMultiChannelWriter(task.Stream);
+                return Observable.Using(
+                    () => Disposable.Create(() =>
+                    {
+                        if (task.Timing.SampleQuantityMode == SampleQuantityMode.FiniteSamples)
+                        {
+                            task.WaitUntilDone();
+                        }
+                        task.Stop();
+                        task.Dispose();
+                    }),
+                    resource => source.Do(input =>
+                    {
+                        var data = new byte[input.Rows, input.Cols];
+                        var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+                        try
+                        {
+                            var dataHeader = new Mat(input.Rows, input.Cols, Depth.U8, 1, dataHandle.AddrOfPinnedObject());
+                            if (input.Depth != dataHeader.Depth) CV.Convert(input, dataHeader);
+                            else CV.Copy(input, dataHeader);
+                            digitalOutWriter.WriteMultiSamplePort(autoStart: true, data);
+                        }
+                        finally { dataHandle.Free(); }
                     }));
             });
         }

--- a/Bonsai.DAQmx/DigitalOutput.cs
+++ b/Bonsai.DAQmx/DigitalOutput.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reactive.Linq;
 using NationalInstruments.DAQmx;
 using System.Reactive.Disposables;
@@ -68,7 +68,11 @@ namespace Bonsai.DAQmx
                         task.Stop();
                         task.Dispose();
                     }),
-                    resource => source.Do(input => onNext(digitalOutWriter, input)));
+                    resource => source.Do(input =>
+                    {
+                        try { onNext(digitalOutWriter, input); }
+                        catch { task.Stop(); throw; }
+                    }));
             });
         }
 
@@ -116,6 +120,7 @@ namespace Bonsai.DAQmx
                             else CV.Copy(input, dataHeader);
                             digitalOutWriter.WriteMultiSamplePort(autoStart: true, data);
                         }
+                        catch { task.Stop(); throw; }
                         finally { dataHandle.Free(); }
                     }));
             });

--- a/Bonsai.DAQmx/DigitalOutputChannelConfiguration.cs
+++ b/Bonsai.DAQmx/DigitalOutputChannelConfiguration.cs
@@ -11,5 +11,12 @@ namespace Bonsai.DAQmx
 
         [TypeConverter(typeof(DigitalOutputPhysicalChannelConverter))]
         public string Lines { get; set; }
+
+        public override string ToString()
+        {
+            var channelName = !string.IsNullOrEmpty(ChannelName) ? ChannelName : Lines;
+            if (string.IsNullOrEmpty(channelName)) return base.ToString();
+            else return channelName;
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for buffered digital output, following the design decisions used for `AnalogOutput`. To use buffered output, the input should be a matrix waveform, where rows represent digital output channels and columns are samples in time.

Fixes #5 