### PR TITLE
Cleanup and standardize API specification

### DIFF
--- a/Bonsai.DAQmx/AnalogChannelConfiguration.cs
+++ b/Bonsai.DAQmx/AnalogChannelConfiguration.cs
@@ -5,17 +5,13 @@ namespace Bonsai.DAQmx
     [TypeConverter(typeof(AnalogChannelConfigurationConverter))]
     public abstract class AnalogChannelConfiguration
     {
-        protected AnalogChannelConfiguration()
-        {
-            ChannelName = string.Empty;
-            MinimumValue = -10;
-            MaximumValue = 10;
-        }
+        [Description("Specifies the name to assign to the local created virtual channel. If not specified, the physical channel name will be used.")]
+        public string ChannelName { get; set; } = string.Empty;
 
-        public string ChannelName { get; set; }
+        [Description("Specifies the minimum value to measure or generate, in the specified voltage units.")]
+        public double MinimumValue { get; set; } = -10;
 
-        public double MinimumValue { get; set; }
-
-        public double MaximumValue { get; set; }
+        [Description("Specifies the maximum value to measure or generate, in the specified voltage units.")]
+        public double MaximumValue { get; set; } = 10;
     }
 }

--- a/Bonsai.DAQmx/AnalogInput.cs
+++ b/Bonsai.DAQmx/AnalogInput.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 
 namespace Bonsai.DAQmx
 {
+    [DefaultProperty(nameof(Channels))]
     [Description("Generates a sequence of voltage measurements from one or more DAQmx analog input channels.")]
     public class AnalogInput : Source<Mat>
     {

--- a/Bonsai.DAQmx/AnalogInput.cs
+++ b/Bonsai.DAQmx/AnalogInput.cs
@@ -41,6 +41,7 @@ namespace Bonsai.DAQmx
         [Description("The size of each read buffer, in samples.")]
         public int SamplesPerRead { get; set; }
 
+        [Editor("Bonsai.Design.DescriptiveCollectionEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         [Description("The collection of analog input channels from which to acquire voltage samples.")]
         public Collection<AnalogInputChannelConfiguration> Channels
         {
@@ -52,7 +53,13 @@ namespace Bonsai.DAQmx
             var task = new Task();
             foreach (var channel in channels)
             {
-                task.AIChannels.CreateVoltageChannel(channel.PhysicalChannel, channel.ChannelName, channel.TerminalConfiguration, channel.MinimumValue, channel.MaximumValue, channel.VoltageUnits);
+                task.AIChannels.CreateVoltageChannel(
+                    channel.PhysicalChannel,
+                    channel.ChannelName,
+                    channel.TerminalConfiguration,
+                    channel.MinimumValue,
+                    channel.MaximumValue,
+                    channel.VoltageUnits);
             }
 
             return task;

--- a/Bonsai.DAQmx/AnalogInputChannelConfiguration.cs
+++ b/Bonsai.DAQmx/AnalogInputChannelConfiguration.cs
@@ -5,18 +5,15 @@ namespace Bonsai.DAQmx
 {
     public class AnalogInputChannelConfiguration : AnalogChannelConfiguration
     {
-        public AnalogInputChannelConfiguration()
-        {
-            TerminalConfiguration = AITerminalConfiguration.Differential;
-            VoltageUnits = AIVoltageUnits.Volts;
-        }
-
         [TypeConverter(typeof(AnalogInputPhysicalChannelConverter))]
+        [Description("Specifies the name of the physical channel used to create the local virtual channel.")]
         public string PhysicalChannel { get; set; }
 
-        public AITerminalConfiguration TerminalConfiguration { get; set; }
+        [Description("Specifies the terminal configuration for the channel.")]
+        public AITerminalConfiguration TerminalConfiguration { get; set; } = AITerminalConfiguration.Differential;
 
-        public AIVoltageUnits VoltageUnits { get; set; }
+        [Description("Specifies the units to use to return voltage measurements from the channel.")]
+        public AIVoltageUnits VoltageUnits { get; set; } = AIVoltageUnits.Volts;
 
         public override string ToString()
         {

--- a/Bonsai.DAQmx/AnalogInputChannelConfiguration.cs
+++ b/Bonsai.DAQmx/AnalogInputChannelConfiguration.cs
@@ -21,8 +21,7 @@ namespace Bonsai.DAQmx
         public override string ToString()
         {
             var channelName = !string.IsNullOrEmpty(ChannelName) ? ChannelName : PhysicalChannel;
-            if (string.IsNullOrEmpty(channelName)) return base.ToString();
-            else return channelName;
+            return string.IsNullOrEmpty(channelName) ? GetType().Name : channelName;
         }
     }
 }

--- a/Bonsai.DAQmx/AnalogInputPhysicalChannelConverter.cs
+++ b/Bonsai.DAQmx/AnalogInputPhysicalChannelConverter.cs
@@ -5,9 +5,11 @@ namespace Bonsai.DAQmx
 {
     class AnalogInputPhysicalChannelConverter : StringConverter
     {
-        public override TypeConverter.StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
         {
-            return new StandardValuesCollection(DaqSystem.Local.GetPhysicalChannels(PhysicalChannelTypes.AI, PhysicalChannelAccess.External));
+            return new StandardValuesCollection(DaqSystem.Local.GetPhysicalChannels(
+                PhysicalChannelTypes.AI,
+                PhysicalChannelAccess.External));
         }
 
         public override bool GetStandardValuesSupported(ITypeDescriptorContext context)

--- a/Bonsai.DAQmx/AnalogOutput.cs
+++ b/Bonsai.DAQmx/AnalogOutput.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 
 namespace Bonsai.DAQmx
 {
+    [DefaultProperty(nameof(Channels))]
     [Description("Writes a sequence of sample buffers to one or more DAQmx analog output channels.")]
     public class AnalogOutput : Sink<Mat>
     {

--- a/Bonsai.DAQmx/AnalogOutput.cs
+++ b/Bonsai.DAQmx/AnalogOutput.cs
@@ -38,6 +38,7 @@ namespace Bonsai.DAQmx
         [Description("The number of samples to generate, for finite samples, or the size of the buffer for continuous sampling.")]
         public int BufferSize { get; set; }
 
+        [Editor("Bonsai.Design.DescriptiveCollectionEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         [Description("The collection of analog output channels used to generate voltage.")]
         public Collection<AnalogOutputChannelConfiguration> Channels
         {
@@ -51,7 +52,12 @@ namespace Bonsai.DAQmx
                 var task = new Task();
                 foreach (var channel in channels)
                 {
-                    task.AOChannels.CreateVoltageChannel(channel.PhysicalChannel, channel.ChannelName, channel.MinimumValue, channel.MaximumValue, channel.VoltageUnits);
+                    task.AOChannels.CreateVoltageChannel(
+                        channel.PhysicalChannel,
+                        channel.ChannelName,
+                        channel.MinimumValue,
+                        channel.MaximumValue,
+                        channel.VoltageUnits);
                 }
 
                 task.Control(TaskAction.Verify);

--- a/Bonsai.DAQmx/AnalogOutputChannelConfiguration.cs
+++ b/Bonsai.DAQmx/AnalogOutputChannelConfiguration.cs
@@ -5,15 +5,12 @@ namespace Bonsai.DAQmx
 {
     public class AnalogOutputChannelConfiguration : AnalogChannelConfiguration
     {
-        public AnalogOutputChannelConfiguration()
-        {
-            VoltageUnits = AOVoltageUnits.Volts;
-        }
-
         [TypeConverter(typeof(AnalogOutputPhysicalChannelConverter))]
+        [Description("Specifies the name of the physical channel used to create the local virtual channel.")]
         public string PhysicalChannel { get; set; }
 
-        public AOVoltageUnits VoltageUnits { get; set; }
+        [Description("Specifies in what units to generate voltage on the channel.")]
+        public AOVoltageUnits VoltageUnits { get; set; } = AOVoltageUnits.Volts;
 
         public override string ToString()
         {

--- a/Bonsai.DAQmx/AnalogOutputChannelConfiguration.cs
+++ b/Bonsai.DAQmx/AnalogOutputChannelConfiguration.cs
@@ -18,8 +18,7 @@ namespace Bonsai.DAQmx
         public override string ToString()
         {
             var channelName = !string.IsNullOrEmpty(ChannelName) ? ChannelName : PhysicalChannel;
-            if (string.IsNullOrEmpty(channelName)) return base.ToString();
-            else return channelName;
+            return string.IsNullOrEmpty(channelName) ? GetType().Name : channelName;
         }
     }
 }

--- a/Bonsai.DAQmx/AnalogOutputPhysicalChannelConverter.cs
+++ b/Bonsai.DAQmx/AnalogOutputPhysicalChannelConverter.cs
@@ -5,9 +5,11 @@ namespace Bonsai.DAQmx
 {
     class AnalogOutputPhysicalChannelConverter : StringConverter
     {
-        public override TypeConverter.StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
         {
-            return new StandardValuesCollection(DaqSystem.Local.GetPhysicalChannels(PhysicalChannelTypes.AO, PhysicalChannelAccess.External));
+            return new StandardValuesCollection(DaqSystem.Local.GetPhysicalChannels(
+                PhysicalChannelTypes.AO,
+                PhysicalChannelAccess.External));
         }
 
         public override bool GetStandardValuesSupported(ITypeDescriptorContext context)

--- a/Bonsai.DAQmx/DigitalChannelConfiguration.cs
+++ b/Bonsai.DAQmx/DigitalChannelConfiguration.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 
 namespace Bonsai.DAQmx
 {
-    [TypeConverter(typeof(AnalogChannelConfigurationConverter))]
+    [TypeConverter(typeof(DigitalChannelConfigurationConverter))]
     public abstract class DigitalChannelConfiguration
     {
         protected DigitalChannelConfiguration()

--- a/Bonsai.DAQmx/DigitalChannelConfiguration.cs
+++ b/Bonsai.DAQmx/DigitalChannelConfiguration.cs
@@ -6,13 +6,10 @@ namespace Bonsai.DAQmx
     [TypeConverter(typeof(DigitalChannelConfigurationConverter))]
     public abstract class DigitalChannelConfiguration
     {
-        protected DigitalChannelConfiguration()
-        {
-            ChannelName = string.Empty;
-        }
+        [Description("Specifies the name of the virtual channel.")]
+        public string ChannelName { get; set; } = string.Empty;
 
-        public string ChannelName { get; set; }
-
+        [Description("Specifies how to group digital lines into one or more virtual channels.")]
         public ChannelLineGrouping Grouping { get; set; }
     }
 }

--- a/Bonsai.DAQmx/DigitalChannelConfigurationConverter.cs
+++ b/Bonsai.DAQmx/DigitalChannelConfigurationConverter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Bonsai.DAQmx
+{
+    class DigitalChannelConfigurationConverter : TypeConverter
+    {
+        public override bool GetPropertiesSupported(ITypeDescriptorContext context)
+        {
+            return true;
+        }
+
+        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
+        {
+            var properties = TypeDescriptor.GetProperties(value, true);
+            return properties.Sort(new[] { "Lines" });
+        }
+    }
+}

--- a/Bonsai.DAQmx/DigitalInput.cs
+++ b/Bonsai.DAQmx/DigitalInput.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 
 namespace Bonsai.DAQmx
 {
+    [DefaultProperty(nameof(Channels))]
     [Description("Generates a sequence of logical values from one or more DAQmx digital input channels.")]
     public class DigitalInput : Source<Mat>
     {

--- a/Bonsai.DAQmx/DigitalInput.cs
+++ b/Bonsai.DAQmx/DigitalInput.cs
@@ -41,6 +41,7 @@ namespace Bonsai.DAQmx
         [Description("The size of each read buffer, in samples.")]
         public int SamplesPerRead { get; set; }
 
+        [Editor("Bonsai.Design.DescriptiveCollectionEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         [Description("The collection of digital input channels from which to acquire logical values.")]
         public Collection<DigitalInputChannelConfiguration> Channels
         {

--- a/Bonsai.DAQmx/DigitalInputChannelConfiguration.cs
+++ b/Bonsai.DAQmx/DigitalInputChannelConfiguration.cs
@@ -15,8 +15,7 @@ namespace Bonsai.DAQmx
         public override string ToString()
         {
             var channelName = !string.IsNullOrEmpty(ChannelName) ? ChannelName : Lines;
-            if (string.IsNullOrEmpty(channelName)) return base.ToString();
-            else return channelName;
+            return string.IsNullOrEmpty(channelName) ? GetType().Name : channelName;
         }
     }
 }

--- a/Bonsai.DAQmx/DigitalInputChannelConfiguration.cs
+++ b/Bonsai.DAQmx/DigitalInputChannelConfiguration.cs
@@ -4,13 +4,9 @@ namespace Bonsai.DAQmx
 {
     public class DigitalInputChannelConfiguration : DigitalChannelConfiguration
     {
-        public DigitalInputChannelConfiguration()
-        {
-            Lines = string.Empty;
-        }
-
         [TypeConverter(typeof(DigitalInputPhysicalChannelConverter))]
-        public string Lines { get; set; }
+        [Description("Specifies the names of the digital lines or ports to use to create the virtual channel.")]
+        public string Lines { get; set; } = string.Empty;
 
         public override string ToString()
         {

--- a/Bonsai.DAQmx/DigitalInputPhysicalChannelConverter.cs
+++ b/Bonsai.DAQmx/DigitalInputPhysicalChannelConverter.cs
@@ -5,9 +5,11 @@ namespace Bonsai.DAQmx
 {
     class DigitalInputPhysicalChannelConverter : StringConverter
     {
-        public override TypeConverter.StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
         {
-            return new StandardValuesCollection(DaqSystem.Local.GetPhysicalChannels(PhysicalChannelTypes.DILine, PhysicalChannelAccess.External));
+            return new StandardValuesCollection(DaqSystem.Local.GetPhysicalChannels(
+                PhysicalChannelTypes.DILine | PhysicalChannelTypes.DIPort,
+                PhysicalChannelAccess.External));
         }
 
         public override bool GetStandardValuesSupported(ITypeDescriptorContext context)

--- a/Bonsai.DAQmx/DigitalOutput.cs
+++ b/Bonsai.DAQmx/DigitalOutput.cs
@@ -38,6 +38,7 @@ namespace Bonsai.DAQmx
         [Description("The number of samples to generate, for finite samples, or the size of the buffer for continuous sampling.")]
         public int BufferSize { get; set; }
 
+        [Editor("Bonsai.Design.DescriptiveCollectionEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         [Description("The collection of digital output channels used to generate digital signals.")]
         public Collection<DigitalOutputChannelConfiguration> Channels
         {

--- a/Bonsai.DAQmx/DigitalOutput.cs
+++ b/Bonsai.DAQmx/DigitalOutput.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 
 namespace Bonsai.DAQmx
 {
+    [DefaultProperty(nameof(Channels))]
     [Description("Writes a sequence of logical values to one or more DAQmx digital output channels.")]
     public class DigitalOutput : Sink<Mat>
     {

--- a/Bonsai.DAQmx/DigitalOutputChannelConfiguration.cs
+++ b/Bonsai.DAQmx/DigitalOutputChannelConfiguration.cs
@@ -15,8 +15,7 @@ namespace Bonsai.DAQmx
         public override string ToString()
         {
             var channelName = !string.IsNullOrEmpty(ChannelName) ? ChannelName : Lines;
-            if (string.IsNullOrEmpty(channelName)) return base.ToString();
-            else return channelName;
+            return string.IsNullOrEmpty(channelName) ? GetType().Name : channelName;
         }
     }
 }

--- a/Bonsai.DAQmx/DigitalOutputChannelConfiguration.cs
+++ b/Bonsai.DAQmx/DigitalOutputChannelConfiguration.cs
@@ -4,13 +4,9 @@ namespace Bonsai.DAQmx
 {
     public class DigitalOutputChannelConfiguration : DigitalChannelConfiguration
     {
-        public DigitalOutputChannelConfiguration()
-        {
-            Lines = string.Empty;
-        }
-
         [TypeConverter(typeof(DigitalOutputPhysicalChannelConverter))]
-        public string Lines { get; set; }
+        [Description("Specifies the names of the digital lines or ports to use to create the virtual channel.")]
+        public string Lines { get; set; } = string.Empty;
 
         public override string ToString()
         {

--- a/Bonsai.DAQmx/DigitalOutputPhysicalChannelConverter.cs
+++ b/Bonsai.DAQmx/DigitalOutputPhysicalChannelConverter.cs
@@ -5,9 +5,11 @@ namespace Bonsai.DAQmx
 {
     class DigitalOutputPhysicalChannelConverter : StringConverter
     {
-        public override TypeConverter.StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
         {
-            return new StandardValuesCollection(DaqSystem.Local.GetPhysicalChannels(PhysicalChannelTypes.DOLine, PhysicalChannelAccess.External));
+            return new StandardValuesCollection(DaqSystem.Local.GetPhysicalChannels(
+                PhysicalChannelTypes.DOLine | PhysicalChannelTypes.DOPort,
+                PhysicalChannelAccess.External));
         }
 
         public override bool GetStandardValuesSupported(ITypeDescriptorContext context)


### PR DESCRIPTION
This PR polishes a few remaining bits around the API for DAQmx operators. Consistent description and enumeration of properties is now in place for all input and output operators.