### PR TITLE
Pack correct DAQmx references for scripting

### DIFF
--- a/src/Bonsai.DAQmx/Bonsai.DAQmx.csproj
+++ b/src/Bonsai.DAQmx/Bonsai.DAQmx.csproj
@@ -5,7 +5,7 @@
     <Description>Bonsai DAQmx Library containing modules for acquisition and control of NI-DAQmx boards.</Description>
     <PackageTags>Bonsai Rx DAQmx</PackageTags>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.2.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bonsai.DAQmx/Bonsai.DAQmx.props
+++ b/src/Bonsai.DAQmx/Bonsai.DAQmx.props
@@ -2,12 +2,12 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="'$(Platform)' == 'x86'">
     <Reference Include="NationalInstruments.DAQmx">
-      <HintPath>$(MSBuildThisFileDirectory)../../build/net45/bin/x86/NationalInstruments.DAQmx.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)../../build/net462/bin/x86/NationalInstruments.DAQmx.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup Condition="'$(Platform)' == 'x64'">
     <Reference Include="NationalInstruments.DAQmx">
-      <HintPath>$(MSBuildThisFileDirectory)../../build/net45/bin/x64/NationalInstruments.DAQmx.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)../../build/net462/bin/x64/NationalInstruments.DAQmx.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR fixes obsolete DAQmx references in the NuGet package to allow custom scripting language extensions to directly target the DAQmx API after adding a `Bonsai.DAQmx` package reference.