### PR TITLE
Add support for all types of sample data buffers

### DIFF
--- a/src/Bonsai.DAQmx/Bonsai.DAQmx.csproj
+++ b/src/Bonsai.DAQmx/Bonsai.DAQmx.csproj
@@ -5,7 +5,7 @@
     <Description>Bonsai DAQmx Library containing modules for acquisition and control of NI-DAQmx boards.</Description>
     <PackageTags>Bonsai Rx DAQmx</PackageTags>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>0.2.1</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR extends `DigitalOutput` with overloads accepting all available types of sample data buffers used to write the state of digital output lines. Some NI-DAQ boards expose digital ports with 16 or 32 lines which can only be updated with the corresponding 16-bit or 32-bit overloads.

With this update, both single sample and multi-sample overloads are also supported, and `Mat` inputs will be automatically converted to the matching buffer type.